### PR TITLE
feat: Add default user to sudo group

### DIFF
--- a/scripts/users/sudo-user/customize
+++ b/scripts/users/sudo-user/customize
@@ -16,7 +16,8 @@ chroot "$1" groupadd -r i2c || true
 chroot "$1" groupadd -r spi || true
 chroot "$1" groupadd -r gpio || true
 chroot "$1" groupadd -r dialout || true
-chroot "$1" usermod -a -G i2c,spi,gpio,dialout ${SUDO_USERNAME} || true
+chroot "$1" groupadd -r sudo || true
+chroot "$1" usermod -a -G i2c,spi,gpio,dialout,sudo ${SUDO_USERNAME} || true
 
 cat <<EOF > "$1/etc/sudoers.d/${SUDO_USERNAME}"
 ${SUDO_USERNAME} ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
Created default user is sudoer but is not member of grou sudo. Add default user to group sudo