### PR TITLE
Remove altboot from essential packages

### DIFF
--- a/unipi/Kconfig
+++ b/unipi/Kconfig
@@ -85,9 +85,9 @@ config UNIPI_ESSENTIAL
 
 config UNIPI_ALTBOOT
 	bool "Install Unipi altboot package"
-	default y if OEMZULU || ZULU
+	default y if OEMZULU || ZULU || GATE || EDGE
 	help
-	  Install Unipi altboot package
+	  Provides "service mode".
 
 config UNIPI_RECOMMENDED
 	bool "Install Unipi specific recommended packages"
@@ -96,7 +96,6 @@ config UNIPI_RECOMMENDED
 	  Install important packages to use all Unipi hardware component.
 	    - unipi-kernel-modules for access to hw components
 	    - os-configurator to self configure OS
-	    - altboot to enable service boot mode
 	    - unipi-modbus-tools (modbus server), mbpoll (modbus client)
 
 config UNIPI_LOCALES

--- a/unipi/Makefile
+++ b/unipi/Makefile
@@ -10,7 +10,7 @@ pkgs-$(CONFIG_UNIPI_ESSENTIAL) += $(if $(findstring y,$(CONFIG_SOC_BCM)),raspi-f
 
 pkgs-$(CONFIG_UNIPI_ALTBOOT) += unipi-altboot
 
-pkgs-$(CONFIG_UNIPI_RECOMMENDED) += unipi-os-configurator,unipi-os-configurator-data,unipi-altboot
+pkgs-$(CONFIG_UNIPI_RECOMMENDED) += unipi-os-configurator,unipi-os-configurator-data
 pkgs-$(CONFIG_UNIPI_RECOMMENDED) += ca-certificates,mbpoll,minicom
 pkgs-$(CONFIG_UNIPI_RECOMMENDED) += unipi-flash-diag,unipi-firmware-tools,unipi-firmware6,$(UNIPI_MODBUS)
 pkgs-$(CONFIG_UNIPI_RECOMMENDED) += $(if $(findstring y,$(CONFIG_EDGE)),unipi-firmware-52)


### PR DESCRIPTION
- listed in a separate option
- Neuron can not have it