### PR TITLE
Turn off rpi sources for Neuron by default

### DIFF
--- a/addons/raspberry/Kconfig
+++ b/addons/raspberry/Kconfig
@@ -1,4 +1,3 @@
 config RPI_SOURCE
 	bool  "Enable Raspberry Pi Apt repositories"
-	default y if NEURON
-	default n if SOC_IMX || SOC_ROCK
+	default n


### PR DESCRIPTION
Not needed. There is also issue with the addon at the moment:

```
Hit:1 http://security.debian.org/debian-security trixie-security InRelease
Hit:2 http://deb.debian.org/debian trixie InRelease
Hit:3 http://deb.debian.org/debian trixie-updates InRelease
Hit:4 https://repo.unipi.technology/debian trixie InRelease
Get:5 http://archive.raspberrypi.org/debian trixie InRelease [54.8 kB]
Err:5 http://archive.raspberrypi.org/debian trixie InRelease
  Sub-process /usr/bin/sqv returned an error code (1), error message is: Signing key on CF8A1AF502A2AA2D763BAE7E82B129927FA3303E is not bound:            No binding signature at time 2026-06-09T11:05:40Z   because: Policy rejected non-revocation signature (PositiveCertification) requiring second pre-image resistance   because: SHA1 is not considered secure since 2026-02-01T00:00:00Z
Warning: OpenPGP signature verification failed: http://archive.raspberrypi.org/debian trixie InRelease: Sub-process /usr/bin/sqv returned an error code (1), error message is: Signing key on CF8A1AF502A2AA2D763BAE7E82B129927FA3303E is not bound:            No binding signature at time 2026-06-09T11:05:40Z   because: Policy rejected non-revocation signature (PositiveCertification) requiring second pre-image resistance   because: SHA1 is not considered secure since 2026-02-01T00:00:00Z
Error: The repository 'http://archive.raspberrypi.org/debian trixie InRelease' is not signed.
Notice: Updating from such a repository can't be done securely, and is therefore disabled by default.
Notice: See apt-secure(8) manpage for repository creation and user configuration details.
```