### PR TITLE
feat: Add apt component for Neuron

### DIFF
--- a/unipi/unipi-source/source
+++ b/unipi/unipi-source/source
@@ -5,6 +5,8 @@
 
 if [ "$OEMZULU" = "y" ]; then
 echo "deb https://repo.unipi.technology/debian ${DEBIAN_SUITE-bookworm} .${PRODUCT}-main zulu-main main"
+elif [ "$NEURON" = "y" ]; then
+echo "deb https://repo.unipi.technology/debian ${DEBIAN_SUITE-bookworm} ${PRODUCT}-main unimodules-main main"
 else
 echo "deb https://repo.unipi.technology/debian ${DEBIAN_SUITE-bookworm} ${PRODUCT}-main main"
 fi


### PR DESCRIPTION
Binary packages unipi-kernel-modules for Neuron are in specific repo component "unimodules-main"